### PR TITLE
Tweet new entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ install:
   - pip install jinja2 PyYAML
 script:
   - "build/build && if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]; then build/upload; fi"
+  - "if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]; then build/tweet; fi"
 notifications:
   email:
     - remirampin@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - 2.7
 sudo: false
 install:
-  - pip install jinja2 PyYAML
+  - pip install jinja2 PyYAML tweepy
 script:
   - "build/build && if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]; then build/upload; fi"
   - "if [ $TRAVIS_BRANCH = master ] && [ $TRAVIS_PULL_REQUEST = false ]; then build/tweet; fi"

--- a/build/tweet
+++ b/build/tweet
@@ -1,0 +1,96 @@
+#!/usr/bin/env python
+
+from __future__ import unicode_literals
+
+import itertools
+import os
+import re
+import sys
+import time
+import tweepy
+
+from parse import list_entries
+
+
+MAX_ENTRIES = 50
+
+
+auth = tweepy.OAuthHandler(os.environ['TWITTER_CONSUMER_KEY'],
+                           os.environ['TWITTER_CONSUMER_SECRET'])
+auth.set_access_token(os.environ['TWITTER_ACCESS_TOKEN'],
+                      os.environ['TWITTER_ACCESS_SECRET'])
+api = tweepy.API(auth)
+
+
+def load_latest_tweets():
+    """Load the latest tweets from the timeline.
+    """
+    return [tweet.text for tweet in api.get_user('ReproFeed').timeline()]
+
+alphanum = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
+
+
+def shorten(text, length=115):
+    """Truncate the text if it is too long.
+    """
+    if len(text) > length:
+        pos = text.rfind(' ', 0, length - 2)
+        if pos == -1:
+            pos = length - 3
+        return text[:pos] + "..."
+    else:
+        return text
+
+
+def has_been_tweeted(last_tweets, entry):
+    """Find whether this entry is present in the list of latest tweets.
+    """
+    text = shorten(entry['title'])
+
+    pattern = ['^']
+    for c in text:
+        if c in alphanum:
+            pattern.append(c)
+        else:
+            pattern.append('.')
+    pattern = re.compile(''.join(pattern))
+
+    for tweet in last_tweets:
+        if pattern.match(tweet):
+            return True
+
+    return False
+
+def tweet(entries):
+    """Tweet a list of entries.
+    """
+    sys.stderr.write("Sending %d tweets...\n" % len(entries))
+
+    for entry in entries:
+        time.sleep(60)
+        text = "%s %s" % (shorten(entry['title']), entry['link'])
+        sys.stderr.write("TWEET: %s\n" % text)
+        api.update_status(text)
+
+def main():
+    # Load the latest tweets from Twitter
+    last_tweets = load_latest_tweets()
+
+    # Go over the entries, accumulating them in a list, until we found one we
+    # already tweeted
+    to_tweet = []
+    for entry in itertools.islice(list_entries('news.yaml'), MAX_ENTRIES):
+        if has_been_tweeted(last_tweets, entry):
+            # Ok, tweet the entries we accumulated
+            tweet(list(reversed(to_tweet)))
+            sys.exit(0)
+
+        to_tweet.append(entry)
+
+    sys.stderr.write("Couldn't tweet: couldn't find a known last tweet\n")
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Fixes #4

This finds the new entries by retrieving the latest tweets from Twitter, then tweets the new entries.

@VickySteeves I need API info for ReproFeed (and do we use those somewhere else?)

Also need to disable tweeting from WordPress.